### PR TITLE
Add php-ldap into required_packages

### DIFF
--- a/data/os/Debian-18.04.yaml
+++ b/data/os/Debian-18.04.yaml
@@ -3,6 +3,7 @@ observium::required_packages:
   - 'wget'
   - 'libapache2-mod-php7.2'
   - 'php7.2-cli'
+  - 'php7.2-ldap'
   - 'php7.2-mysql'
   - 'php7.2-mysqli'
   - 'php7.2-gd'

--- a/data/os/Debian-20.04.yaml
+++ b/data/os/Debian-20.04.yaml
@@ -3,6 +3,7 @@ observium::required_packages:
   - 'wget'
   - 'libapache2-mod-php7.4'
   - 'php7.4-cli'
+  - 'php7.4-ldap'
   - 'php7.4-mysql'
   - 'php7.4-gd'
   - 'php7.4-json'

--- a/data/os/RedHat-7.yaml
+++ b/data/os/RedHat-7.yaml
@@ -50,6 +50,7 @@ observium::repos:
 observium::required_packages:
   - 'wget'
   - 'php'
+  - 'php-ldap'
   - 'php-opcache'
   - 'php-mysql'
   - 'php-gd'

--- a/data/os/RedHat-8.yaml
+++ b/data/os/RedHat-8.yaml
@@ -44,6 +44,7 @@ observium::repos:
 observium::required_packages:
   - 'wget'
   - 'php'
+  - 'php-ldap'
   - 'php-opcache'
   - 'php-mysqlnd'
   - 'php-gd'


### PR DESCRIPTION
adding extra settings via `observium_additional_conf` make it possible that one uses this puppet module to power up the Observium setup and use its LDAP support to authenticate accounts against it, **but the `php-ldap` package was missing** at the `required_packages` array for either _Debian-_ or _RedHat-like_ distributions.

by merging this pull request we would be able to:
  - install `php-ldap` as required package;
  - use Observium's LDAP support;
  - customize our setup to enable LDAP authentication.

this setup and tests were satisfied using **puppet** 6.x with eyaml and hiera. here is how the node config's look like:

##### ~ cat data/nodes/observium.xxx.yaml 

```
---
classes:
    - 'profile::freeipa'
    - 'profile::observium'
    - 'xxx_ssh_keys'

observium:
    admin_password: ENC[PKCS7,MIIBiQYJ ...
    db_password: ENC[PKCS7,MIIBiQYJKoZIhv ...
    snmpv3_authpass: ENC[PKCS7,MIIBiQYJKoZIhv
    snmpv3_cryptopass: ENC[PKCS7,MIIBiQYJKoZIhv
    observium_additional_conf:
        - $config['auth_ldap_bindanonymous'] = FALSE;
        - $config['auth_ldap_binddn'] = " 😸 ";
        - $config['auth_ldap_bindpw'] = ENC[PKCS7,MIIBiQYJK ....
        - $config['auth_ldap_group']  = array("😸");
        - $config['auth_ldap_groupbase'] = "😸";
        - $config['auth_ldap_groupmembertype'] = "fulldn";
        - $config['auth_ldap_groups'][' 😸 ']['level']  = 10;
        - $config['auth_ldap_groupreverse'] = TRUE;
        - $config['auth_ldap_objectclass'] = "person";
        - $config['auth_ldap_port']   = 636;
        - $config['auth_ldap_server'] = "ldaps://xxx";
        - $config['auth_ldap_suffix'] = "😸";
```

##### ~ cat site/profile/manifests/observium.pp 

```
# Class: profile::observium
#
#
class profile::observium {

  $passwd_admin = lookup('observium.admin_password', String, first, '🥧')
  $passwd_dbase = lookup('observium.db_password', String, first, '🥧')
  $passwd_snmpv3_auth   = lookup('observium.snmpv3_authpass', String, first, '🥧')
  $passwd_snmpv3_crypto = lookup('observium.snmpv3_cryptopass', String, first, '🥧')
  $observium_additional_cfg = lookup('observium.observium_additional_conf', Array, first, ['🥧'])

  class { 'observium':
    admin_password => $passwd_admin,
    db_password    => $passwd_dbase,
    snmpv3_authpass   => $passwd_snmpv3_auth,
    snmpv3_cryptopass => $passwd_snmpv3_crypto,
    observium_additional_conf => $observium_additional_cfg,
  }
}
```

journalctl's entries related to the success ran of the agent:

```
Feb 23 12:24:49 observium.xxx svn[13538]: DIGEST-MD5 common mech free
Feb 23 12:24:56 observium.xxx puppet-agent[13483]: (/Stage[main]/Observium::Database_init/Exec[/opt/observium/adduser.php admin 🥇  10]/returns) executed successfully (corrective)
Feb 23 12:24:56 observium.xxx puppet-agent[13483]: Applied catalog in 1.92 seconds
```