### PR TITLE
Observium Module Security Fixes

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,7 +1,7 @@
 ---
 observium::auth_mechanism: "mysql"
-observium::db_password: "changeme"
-observium::rootdb_password: "hello123"
+observium::db_password: "changeme"  # TODO: NO PASSWORDS IN DATA FILES
+observium::rootdb_password: "hello123"  # TODO: NO PASSWORDS IN DATA FILES
 observium::download_url: "http://www.observium.org/"
 observium::installer_name: "observium-community-latest.tar.gz"
 observium::install_dir: "/opt/observium"
@@ -10,9 +10,9 @@ observium::db_user: "observium"
 observium::community: "puppet"
 observium::snmpv3_authlevel: "authPriv"
 observium::snmpv3_authname: "observium"
-observium::snmpv3_authpass: "setme1234"
+observium::snmpv3_authpass: "setme1234" # TODO: NO PASSWORDS IN DATA FILES
 observium::snmpv3_authalgo: "SHA"
-observium::snmpv3_cryptopass: "setme1234"
+observium::snmpv3_cryptopass: "setme1234" # TODO: NO PASSWORDS IN DATA FILES
 observium::snmpv3_cryptoalgo: "AES"
 observium::mib_locations:
   - /opt/observium/mibs/rfc
@@ -23,7 +23,7 @@ observium::observium_additional_conf:
   - '//extra lines'
   - '//as many as you'
   - '//would like'
-observium::admin_password: "changeme"
+observium::admin_password: "changeme"  # TODO: NO PASSWORDS IN DATA FILES
 observium::apache_custom_options: {}
 observium::apache_auth_require: "all granted"
 observium::apache_port: 80

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,7 +1,5 @@
 ---
 observium::auth_mechanism: "mysql"
-observium::db_password: "changeme"  # TODO: NO PASSWORDS IN DATA FILES
-observium::rootdb_password: "hello123"  # TODO: NO PASSWORDS IN DATA FILES
 observium::download_url: "http://www.observium.org/"
 observium::installer_name: "observium-community-latest.tar.gz"
 observium::install_dir: "/opt/observium"
@@ -10,9 +8,7 @@ observium::db_user: "observium"
 observium::community: "puppet"
 observium::snmpv3_authlevel: "authPriv"
 observium::snmpv3_authname: "observium"
-observium::snmpv3_authpass: "setme1234" # TODO: NO PASSWORDS IN DATA FILES
 observium::snmpv3_authalgo: "SHA"
-observium::snmpv3_cryptopass: "setme1234" # TODO: NO PASSWORDS IN DATA FILES
 observium::snmpv3_cryptoalgo: "AES"
 observium::mib_locations:
   - /opt/observium/mibs/rfc
@@ -23,7 +19,6 @@ observium::observium_additional_conf:
   - '//extra lines'
   - '//as many as you'
   - '//would like'
-observium::admin_password: "changeme"  # TODO: NO PASSWORDS IN DATA FILES
 observium::apache_custom_options: {}
 observium::apache_auth_require: "all granted"
 observium::apache_port: 80

--- a/manifests/database_init.pp
+++ b/manifests/database_init.pp
@@ -10,7 +10,6 @@ class observium::database_init {
   # Lookup location of mysql binary
   $mysql_location = lookup(observium::mysql_location, String)
 
-  # TODO: is this right?
   # init the database if the user table is not present
   exec { 'init observium databse':
     command => '/opt/observium/discovery.php -u',

--- a/manifests/database_init.pp
+++ b/manifests/database_init.pp
@@ -14,12 +14,12 @@ class observium::database_init {
   # init the database if the user table is not present
   exec { 'init observium databse':
     command => '/opt/observium/discovery.php -u',
-    unless  => "${mysql_location} -u ${observium::db_user} --password='${observium::db_password}' observium -e 'select * from observium.users'",
+    unless  => "${mysql_location} -u ${observium::db_user} --password='${observium::db_password}' observium -e \"select * from observium.users\"",
   }
 
   exec { 'Create admin user':
     command => "/opt/observium/adduser.php admin ${observium::admin_password} 10",
-    unless  => "${mysql_location} -u ${observium::db_user} --password='${observium::db_password}' observium -e 'select * from observium.users WHERE username LIKE \"admin\"' | grep admin",
+    unless  => "${mysql_location} -u ${observium::db_user} --password='${observium::db_password}' observium -e \"select * from observium.users WHERE username LIKE 'admin'\" | grep admin",
   }
 
   # add local host to database

--- a/manifests/database_init.pp
+++ b/manifests/database_init.pp
@@ -10,6 +10,7 @@ class observium::database_init {
   # Lookup location of mysql binary
   $mysql_location = lookup(observium::mysql_location, String)
 
+  # TODO: is this right?
   # init the database if the user table is not present
   exec { 'init observium databse':
     command => '/opt/observium/discovery.php -u',

--- a/manifests/database_init.pp
+++ b/manifests/database_init.pp
@@ -14,12 +14,12 @@ class observium::database_init {
   # init the database if the user table is not present
   exec { 'init observium databse':
     command => '/opt/observium/discovery.php -u',
-    unless  => "${mysql_location} -u ${observium::db_user} --password=${observium::db_password} observium -e 'select * from observium.users'",
+    unless  => "${mysql_location} -u ${observium::db_user} --password='${observium::db_password}' observium -e 'select * from observium.users'",
   }
 
   exec { 'Create admin user':
     command => "/opt/observium/adduser.php admin ${observium::admin_password} 10",
-    unless  => "${mysql_location} -u ${observium::db_user} --password=${observium::db_password} observium -e 'select * from observium.users WHERE username LIKE \"admin\"' | grep admin",
+    unless  => "${mysql_location} -u ${observium::db_user} --password='${observium::db_password}' observium -e 'select * from observium.users WHERE username LIKE \"admin\"' | grep admin",
   }
 
   # add local host to database
@@ -31,7 +31,7 @@ class observium::database_init {
   }
   exec { 'Add local host as device':
     command => "/opt/observium/add_device.php 127.0.0.1 ${v3auth} v3 ${observium::snmpv3_authname} ${observium::snmpv3_authpass} ${observium::snmpv3_cryptopass} ${observium::snmpv3_authalgo} ${observium::snmpv3_cryptoalgo}",
-    unless  => "${mysql_location} -u ${observium::db_user} --password=${observium::db_password} observium -e 'select hostname from devices WHERE hostname LIKE \"127.0.0.1\"' | grep 127.0.0.1",
+    unless  => "${mysql_location} -u ${observium::db_user} --password='${observium::db_password}' observium -e 'select hostname from devices WHERE hostname LIKE \"127.0.0.1\"' | grep 127.0.0.1",
   }
 
   # Perform discovery for nodes which have been added. 

--- a/manifests/database_init.pp
+++ b/manifests/database_init.pp
@@ -14,12 +14,12 @@ class observium::database_init {
   # init the database if the user table is not present
   exec { 'init observium databse':
     command => '/opt/observium/discovery.php -u',
-    unless  => "${mysql_location} -u ${observium::db_user} --password=${observium::db_password} observium -e 'select * from users'",
+    unless  => "${mysql_location} -u ${observium::db_user} --password=${observium::db_password} observium -e 'select * from observium.users'",
   }
 
   exec { 'Create admin user':
     command => "/opt/observium/adduser.php admin ${observium::admin_password} 10",
-    unless  => "${mysql_location} -u ${observium::db_user} --password=${observium::db_password} observium -e 'select * from users WHERE username LIKE \"admin\"' | grep admin",
+    unless  => "${mysql_location} -u ${observium::db_user} --password=${observium::db_password} observium -e 'select * from observium.users WHERE username LIKE \"admin\"' | grep admin",
   }
 
   # add local host to database

--- a/manifests/database_init.pp
+++ b/manifests/database_init.pp
@@ -14,12 +14,12 @@ class observium::database_init {
   # init the database if the user table is not present
   exec { 'init observium databse':
     command => '/opt/observium/discovery.php -u',
-    unless  => "${mysql_location} -u observium --password=${observium::db_password} observium -e 'select * from users'",
+    unless  => "${mysql_location} -u ${observium::db_user} --password=${observium::db_password} observium -e 'select * from users'",
   }
 
   exec { 'Create admin user':
     command => "/opt/observium/adduser.php admin ${observium::admin_password} 10",
-    unless  => "${mysql_location} -u observium --password=${observium::db_password} observium -e 'select * from users WHERE username LIKE \"admin\"' | grep admin",
+    unless  => "${mysql_location} -u ${observium::db_user} --password=${observium::db_password} observium -e 'select * from users WHERE username LIKE \"admin\"' | grep admin",
   }
 
   # add local host to database
@@ -31,7 +31,7 @@ class observium::database_init {
   }
   exec { 'Add local host as device':
     command => "/opt/observium/add_device.php 127.0.0.1 ${v3auth} v3 ${observium::snmpv3_authname} ${observium::snmpv3_authpass} ${observium::snmpv3_cryptopass} ${observium::snmpv3_authalgo} ${observium::snmpv3_cryptoalgo}",
-    unless  => "${mysql_location} -u observium --password=${observium::db_password} observium -e 'select hostname from devices WHERE hostname LIKE \"127.0.0.1\"' | grep 127.0.0.1",
+    unless  => "${mysql_location} -u ${observium::db_user} --password=${observium::db_password} observium -e 'select hostname from devices WHERE hostname LIKE \"127.0.0.1\"' | grep 127.0.0.1",
   }
 
   # Perform discovery for nodes which have been added. 

--- a/manifests/database_init.pp
+++ b/manifests/database_init.pp
@@ -17,9 +17,12 @@ class observium::database_init {
     unless  => "${mysql_location} -u ${observium::db_user} --password='${observium::db_password}' observium -e \"select * from observium.users\"",
   }
 
-  exec { 'Create admin user':
-    command => "/opt/observium/adduser.php admin ${observium::admin_password} 10",
-    unless  => "${mysql_location} -u ${observium::db_user} --password='${observium::db_password}' observium -e \"select * from observium.users WHERE username LIKE 'admin'\" | grep admin",
+  # when auth_mechanism is 'remote', privilege level is given by observium's auth_remote_userlevel setting
+  unless $observium::auth_mechanism == 'remote' {
+    exec { 'Create admin user':
+      command => "/opt/observium/adduser.php admin ${observium::admin_password} 10",
+      unless  => "${mysql_location} -u ${observium::db_user} --password='${observium::db_password}' observium -e \"select * from observium.users WHERE username LIKE 'admin'\" | grep admin",
+    }
   }
 
   # add local host to database

--- a/manifests/mariadb.pp
+++ b/manifests/mariadb.pp
@@ -6,8 +6,9 @@
 #
 class observium::mariadb {
   assert_private()
+
   # Check we are managing mysql
-  if observium::manage_mysql {
+  if $observium::manage_mysql {
     case $facts['os']['family'] {
       'RedHat': {
         Class { '::mysql::server':
@@ -19,10 +20,6 @@ class observium::mariadb {
       }
       'Debian': {
         Class { '::mysql::server':
-          # TODO: This should not just be commented out.
-          #package_name   => 'mariadb-server',
-          #package_ensure => 'present',
-          #service_name   => 'mysqld',
           root_password    => $observium::rootdb_password,
           override_options => {
             'mysqld' => {

--- a/manifests/mariadb.pp
+++ b/manifests/mariadb.pp
@@ -19,6 +19,7 @@ class observium::mariadb {
       }
       'Debian': {
         Class { '::mysql::server':
+          # TODO: This should not just be commented out.
           #package_name   => 'mariadb-server',
           #package_ensure => 'present',
           #service_name   => 'mysqld',


### PR DESCRIPTION
I fixed a few things:

1. Most importantly, I removed all hard-coded passwords from the data defaults because that is bad practice. I think it's fine to have sample puppet code in the README that has e.g. `password => "changeme"` or whatever, but having it set as a default is not secure and a bad idea, no matter how sophisticated the users of the module are.

2. In `database_init`, I made a few changes:
- the database user is `$observium::db_user` and not simply `observium`, so we should respect that when executing db commands as that user
- having the `auth_mechanism` set to `remote` does not allow users to be added with adduser.php, privileges are controlled via the apache config (see [the docs](https://docs.observium.org/authentication/#apache-remote_user-authentication)), so this command should not be run in this case

I also fixed what appeared to be a typo, removed commented out code, and added some single quotes to ensure funky passwords are respected 